### PR TITLE
Default value for table columns

### DIFF
--- a/resources/js/components/Fjord/BaseIndex/TableCol/TableCol.vue
+++ b/resources/js/components/Fjord/BaseIndex/TableCol/TableCol.vue
@@ -1,206 +1,210 @@
 <template>
-    <b-td
-        :class="{
-            'col-sm': isSmall(col),
-            'fj-table-col': true,
-            pointer: col.link,
-            'text-right': col.text_right,
-            'text-center': col.text_center,
-            ...col.classes
-        }"
-        :style="colWidth"
-    >
-        <component
-            :is="true ? 'a' : 'span'"
-            :href="link"
-            :target="isExternal(link) ? '_blank' : ''"
-        >
-            <component
-                v-if="col.name !== undefined"
-                :is="col.name"
-                :item="item"
-                :col="col"
-                :format="getColValue"
-                @reload="reload"
-                v-on="$listeners"
-                v-bind="getColComponentProps()"
-            />
+	<b-td
+		:class="{
+			'col-sm': isSmall(col),
+			'fj-table-col': true,
+			pointer: col.link,
+			'text-right': col.text_right,
+			'text-center': col.text_center,
+			...col.classes,
+		}"
+		:style="colWidth"
+	>
+		<component
+			:is="true ? 'a' : 'span'"
+			:href="link"
+			:target="isExternal(link) ? '_blank' : ''"
+		>
+			<component
+				v-if="col.name !== undefined"
+				:is="col.name"
+				:item="item"
+				:col="col"
+				:format="getColValue"
+				@reload="reload"
+				v-on="$listeners"
+				v-bind="getColComponentProps()"
+			/>
 
-            <span v-else v-html="value" />
-        </component>
-    </b-td>
+			<span v-else v-html="value" />
+		</component>
+	</b-td>
 </template>
 
 <script>
 import { mapGetters } from 'vuex';
 export default {
-    name: 'TableCol',
-    props: {
-        item: {
-            required: true,
-            type: Object
-        },
-        col: {
-            required: true,
-            type: Object
-        },
-        cols: {
-            required: true,
-            type: Array
-        }
-    },
-    data() {
-        return {
-            value: ''
-        };
-    },
-    watch: {
-        item() {
-            this.setValue();
-        }
-    },
-    beforeMount() {
-        this.setValue();
+	name: 'TableCol',
+	props: {
+		item: {
+			required: true,
+			type: Object,
+		},
+		col: {
+			required: true,
+			type: Object,
+		},
+		cols: {
+			required: true,
+			type: Array,
+		},
+	},
+	data() {
+		return {
+			value: '',
+		};
+	},
+	watch: {
+		item() {
+			this.setValue();
+		},
+	},
+	beforeMount() {
+		this.setValue();
 
-        // Can be called from parents to refresh value.
-        this.$on('refresh', this.setValue);
+		// Can be called from parents to refresh value.
+		this.$on('refresh', this.setValue);
 
-        Fjord.bus.$on('languageChanged', this.setValue);
-    },
-    computed: {
-        ...mapGetters(['baseURL']),
-        percentageColsCount() {
-            let count = 0;
-            for (let i = 0; i < this.cols.length; i++) {
-                let col = this.cols[i];
+		Fjord.bus.$on('languageChanged', this.setValue);
+	},
+	computed: {
+		...mapGetters(['baseURL']),
+		percentageColsCount() {
+			let count = 0;
+			for (let i = 0; i < this.cols.length; i++) {
+				let col = this.cols[i];
 
-                if (this.isSmall(col)) {
-                    continue;
-                }
+				if (this.isSmall(col)) {
+					continue;
+				}
 
-                count++;
-            }
-            return count;
-        },
-        colWidth() {
-            if (this.isSmall(this.col)) {
-                return;
-            }
-            let percentage = 100;
-            if (this.percentageColsCount > 0) {
-                percentage = 100 / this.percentageColsCount;
-            }
-            return 'width: ' + percentage + '%;';
-        },
-        link() {
-            if (!this.col.link) {
-                return;
-            }
+				count++;
+			}
+			return count;
+		},
+		colWidth() {
+			if (this.isSmall(this.col)) {
+				return;
+			}
+			let percentage = 100;
+			if (this.percentageColsCount > 0) {
+				percentage = 100 / this.percentageColsCount;
+			}
+			return 'width: ' + percentage + '%;';
+		},
+		link() {
+			if (!this.col.link) {
+				return;
+			}
 
-            let path = this._format(this.col.link, this.item);
+			let path = this._format(this.col.link, this.item);
 
-            if (!path.includes('//')) {
-                return `${this.baseURL}${path}`;
-            }
+			if (!path.includes('//')) {
+				return `${this.baseURL}${path}`;
+			}
 
-            return path;
-        }
-    },
-    methods: {
-        isExternal(url) {
-            let domain = function(url) {
-                return url
-                    .replace('http://', '')
-                    .replace('https://', '')
-                    .split('/')[0];
-            };
+			return path;
+		},
+	},
+	methods: {
+		isExternal(url) {
+			let domain = function(url) {
+				return url
+					.replace('http://', '')
+					.replace('https://', '')
+					.split('/')[0];
+			};
 
-            if (!url) {
-                return false;
-            }
+			if (!url) {
+				return false;
+			}
 
-            if (!url.includes('//')) {
-                return false;
-            }
+			if (!url.includes('//')) {
+				return false;
+			}
 
-            return domain(location.href) !== domain(url);
-        },
-        setValue() {
-            this.value = this.getColValue(this.col, this.item);
-        },
-        reload() {
-            this.$emit('reload');
-        },
-        getColValue(col, item) {
-            let value = '';
+			return domain(location.href) !== domain(url);
+		},
+		setValue() {
+			this.value = this.getColValue(this.col, this.item);
+		},
+		reload() {
+			this.$emit('reload');
+		},
+		getColValue(col, item) {
+			let value = '';
 
-            if (col.value_options) {
-                value = col.value_options[item[col.value]];
-            } else {
-                value = col.value;
-            }
+			if (col.value_options) {
+				value = col.value_options[item[col.value]];
 
-            // Regex for has {value} pattern.
-            if (/{(.*?)}/.test(value)) {
-                value = this._format(value, item);
-            } else if (item[value] !== undefined && item[value] !== null) {
-                value = item[value];
-            }
+				if (value === undefined && col.default_value) {
+					value = col.default_value;
+				}
+			} else {
+				value = col.value;
+			}
 
-            return this.format(value);
-        },
-        format(value) {
-            if (!value) {
-                return value;
-            }
+			// Regex for has {value} pattern.
+			if (/{(.*?)}/.test(value)) {
+				value = this._format(value, item);
+			} else if (item[value] !== undefined && item[value] !== null) {
+				value = item[value];
+			}
 
-            if (this.col.regex) {
-                value = value.replace(
-                    eval(this.col.regex),
-                    this.col.regex_replace
-                );
-            }
+			return this.format(value);
+		},
+		format(value) {
+			if (!value) {
+				return value;
+			}
 
-            if (this.col.strip_html) {
-                value = value.replace(/<[^>]*>?/gm, ' ');
-            }
+			if (this.col.regex) {
+				value = value.replace(
+					eval(this.col.regex),
+					this.col.regex_replace
+				);
+			}
 
-            if (this.col.max_chars) {
-                if (value.length > this.col.max_chars) {
-                    value = value.substring(0, this.col.max_chars) + '...';
-                }
-            }
+			if (this.col.strip_html) {
+				value = value.replace(/<[^>]*>?/gm, ' ');
+			}
 
-            return value;
-        },
-        getColComponentProps() {
-            if (!this.col.name) {
-                return {};
-            }
+			if (this.col.max_chars) {
+				if (value.length > this.col.max_chars) {
+					value = value.substring(0, this.col.max_chars) + '...';
+				}
+			}
 
-            let compiled = {};
+			return value;
+		},
+		getColComponentProps() {
+			if (!this.col.name) {
+				return {};
+			}
 
-            for (let name in this.col.props) {
-                let prop = this.col.props[name];
-                compiled[name] = prop;
-            }
+			let compiled = {};
 
-            return compiled;
-        },
-        isSmall(col) {
-            return col.small === true;
-        }
-    }
+			for (let name in this.col.props) {
+				let prop = this.col.props[name];
+				compiled[name] = prop;
+			}
+
+			return compiled;
+		},
+		isSmall(col) {
+			return col.small === true;
+		},
+	},
 };
 </script>
 <style lang="scss">
 table.b-table tr td > a {
-    color: unset;
-    &:hover {
-        text-decoration: none;
-    }
+	color: unset;
+	&:hover {
+		text-decoration: none;
+	}
 }
 .fj-col-money {
-    font-variant-numeric: tabular-nums;
+	font-variant-numeric: tabular-nums;
 }
 </style>

--- a/src/Page/Table/Column.php
+++ b/src/Page/Table/Column.php
@@ -64,12 +64,14 @@ class Column extends VueProp implements ColumnInterface
      *
      * @param  string     $value
      * @param  array|null $options
+     * @param  mixed      $default
      * @return $this
      */
-    public function value($value, array $options = null)
+    public function value($value, array $options = null, $default = null)
     {
         $this->setAttribute('value', $value);
         $this->setAttribute('value_options', $options);
+        $this->setAttribute('default_value', $default);
 
         return $this;
     }

--- a/tests/php/Page/ColumnTest.php
+++ b/tests/php/Page/ColumnTest.php
@@ -34,6 +34,22 @@ class ColumnTest extends TestCase
     }
 
     /** @test */
+    public function test_value_method_with_options()
+    {
+        $column = new Column();
+        $column->value('col', ['foo' => 'bar']);
+        $this->assertEquals(['foo' => 'bar'], $column->getAttribute('value_options'));
+    }
+
+    /** @test */
+    public function test_value_method_with_default_value()
+    {
+        $column = new Column();
+        $column->value('foor', [], 'bar');
+        $this->assertEquals('bar', $column->getAttribute('default_value'));
+    }
+
+    /** @test */
     public function test_right_method()
     {
         $column = new Column();


### PR DESCRIPTION
This pr makes it possible to give a table column a default value as third parameter. 

```php
$table->col('State')->value('state', ['foo' => 'bar'], 'default value');
```

#### Example

The following example shows a table with column badges depending on state. If none of the specified options is available, a `secondary` badge with the value of the state attributes is displayed.

```php
$table->col('State')->value('state', [
    'success' => '<div class="badge badge-success">Success</div>',
    'pending' => '<div class="badge badge-info">Pending</div>',
], '<div class="badge badge-secondary">{state}</div>');
```