### PR TITLE
Use __ mixin for js translations

### DIFF
--- a/resources/js/components/Crud/Fields/Block/FieldBlock.vue
+++ b/resources/js/components/Crud/Fields/Block/FieldBlock.vue
@@ -267,7 +267,7 @@ export default {
 
             Fjord.bus.$emit('field:updated', 'block:deleted');
 
-            this.$bvToast.toast(this.$t('fj.deleted_block'), {
+            this.$bvToast.toast(this.__('fj.deleted_block'), {
                 variant: 'success'
             });
         },

--- a/resources/js/components/Crud/Fields/Block/FieldBlockAddRepeatableButtons.vue
+++ b/resources/js/components/Crud/Fields/Block/FieldBlockAddRepeatableButtons.vue
@@ -86,7 +86,7 @@ export default {
          * Show new repeatable toast.
          */
         showNewRepeatableToast(type) {
-            this.$bvToast.toast(this.$t('fj.new_block', { type }), {
+            this.$bvToast.toast(this.__('fj.new_block', { type }), {
                 variant: 'success'
             });
         }

--- a/resources/js/components/Crud/Fields/Block/FieldRepeatableHeader.vue
+++ b/resources/js/components/Crud/Fields/Block/FieldRepeatableHeader.vue
@@ -6,7 +6,7 @@
                     <div
                         class="fj-draggable__dragbar fj-block__dragbar"
                         v-b-tooltip
-                        :title="$t('fj.change_order')"
+                        :title="__('fj.change_order')"
                         v-if="sortable"
                     >
                         <i class="fas fa-grip-horizontal text-secondary"></i>
@@ -24,7 +24,7 @@
                     <b-button
                         variant="transparent"
                         v-b-tooltip
-                        :title="$t('fj.delete_model', { model: 'Block' })"
+                        :title="__('fj.delete_model', { model: 'Block' })"
                         size="sm"
                         class="btn-square fj-block-delete"
                         @click="$emit('deleteItem')"
@@ -35,7 +35,7 @@
                 <b-td class="col-sm pl-2 pr-0" v-if="fields.length > 0">
                     <b-button
                         variant="outline-secondary"
-                        :title="$t('crud.fields.blocks.expand')"
+                        :title="__('crud.fields.blocks.expand')"
                         size="sm"
                         class="btn-square"
                         @click="$emit('toggleExpand')"

--- a/resources/js/components/Crud/Fields/FieldAlertEmpty.vue
+++ b/resources/js/components/Crud/Fields/FieldAlertEmpty.vue
@@ -2,7 +2,7 @@
     <b-alert
         show
         variant="info"
-        v-html="$t('fj.no_relation_selected', { relation: field.title })"
+        v-html="__('fj.no_relation_selected', { relation: field.title })"
     />
 </template>
 

--- a/resources/js/components/Crud/Fields/FieldAlertNotCreated.vue
+++ b/resources/js/components/Crud/Fields/FieldAlertNotCreated.vue
@@ -4,7 +4,7 @@
             show
             variant="warning"
             v-html="
-                $t('fj.not_created', {
+                __('fj.not_created', {
                     relation: field.title,
                     model: 'Item'
                 })

--- a/resources/js/components/Crud/Fields/Media/FieldMediaImages.vue
+++ b/resources/js/components/Crud/Fields/Media/FieldMediaImages.vue
@@ -156,7 +156,7 @@ export default {
                 return;
             }
 
-            this.$bvToast.toast(this.$t('fj.order_changed'), {
+            this.$bvToast.toast(this.__('fj.order_changed'), {
                 variant: 'success'
             });
             this.$emit('newOrder');

--- a/resources/js/components/Crud/Fields/Modal/FieldModal.vue
+++ b/resources/js/components/Crud/Fields/Modal/FieldModal.vue
@@ -48,7 +48,7 @@
                     v-bind:disabled="!canSave"
                     @click="Fjord.bus.$emit('save')"
                 >
-                    {{ $t('fj.save') }}
+                    {{ __('fj.save') }}
                 </b-button>
             </template>
         </b-modal>

--- a/resources/js/components/Crud/Fields/Relation/FieldRelation.vue
+++ b/resources/js/components/Crud/Fields/Relation/FieldRelation.vue
@@ -358,7 +358,7 @@ export default {
             }
 
             this.$bvToast.toast(
-                this.$t('fj.relation_added', {
+                this.__('fj.relation_added', {
                     relation: this.field.title
                 }),
                 {
@@ -429,7 +429,7 @@ export default {
                 return;
             }
 
-            this.$bvToast.toast(this.$t('fj.relation_unlinked'), {
+            this.$bvToast.toast(this.__('fj.relation_unlinked'), {
                 variant: 'success'
             });
 
@@ -489,7 +489,7 @@ export default {
             this.$emit('reload');
             Fjord.bus.$emit('field:updated', 'relation:ordered');
 
-            this.$bvToast.toast(this.$t('fj.order_changed'), {
+            this.$bvToast.toast(this.__('fj.order_changed'), {
                 variant: 'success'
             });
         },

--- a/resources/js/components/Crud/Fields/Relation/FieldRelationColEdit.vue
+++ b/resources/js/components/Crud/Fields/Relation/FieldRelationColEdit.vue
@@ -4,7 +4,7 @@
         size="sm"
         class="btn-square"
         v-b-tooltip.hover
-        :title="$t('crud.fields.relation.edit')"
+        :title="__('crud.fields.relation.edit')"
     >
         <fa-icon icon="edit" @click="edit(item)" />
         <fj-field-relation-form

--- a/resources/js/components/Crud/Fields/Relation/FieldRelationColLink.vue
+++ b/resources/js/components/Crud/Fields/Relation/FieldRelationColLink.vue
@@ -4,7 +4,7 @@
         size="sm"
         class="btn-square"
         v-b-tooltip.hover
-        :title="$t('crud.fields.relation.goto')"
+        :title="__('crud.fields.relation.goto')"
         :href="link"
     >
         <fa-icon icon="eye" />

--- a/resources/js/components/Crud/Fields/Relation/FieldRelationColUnlink.vue
+++ b/resources/js/components/Crud/Fields/Relation/FieldRelationColUnlink.vue
@@ -4,7 +4,7 @@
         size="sm"
         class="btn-square"
         v-b-tooltip.hover
-        :title="$t('crud.fields.relation.unlink')"
+        :title="__('crud.fields.relation.unlink')"
         @click="$emit('unlink', item)"
     >
         <fa-icon icon="unlink" />

--- a/resources/js/components/Crud/Fields/Relation/FieldRelationForm.vue
+++ b/resources/js/components/Crud/Fields/Relation/FieldRelationForm.vue
@@ -17,7 +17,7 @@
                 :disabled="!canSave"
                 @click="Fjord.bus.$emit('save')"
             >
-                {{ $t('fj.save') }}
+                {{ __('fj.save') }}
             </b-button>
         </template>
     </b-modal>

--- a/resources/js/components/Crud/Fields/Relation/FieldRelationIndex.vue
+++ b/resources/js/components/Crud/Fields/Relation/FieldRelationIndex.vue
@@ -166,7 +166,7 @@ export default {
                 payload
             );
 
-            this.$bvToast.toast(this.$t('fj.order_changed'), {
+            this.$bvToast.toast(this.__('fj.order_changed'), {
                 variant: 'success'
             });
         }

--- a/resources/js/components/Crud/Preview/CrudPreview.vue
+++ b/resources/js/components/Crud/Preview/CrudPreview.vue
@@ -7,7 +7,7 @@
     >
         <fa-icon icon="eye" />
 
-        {{ $t('fj.preview') }}
+        {{ __('fj.preview') }}
 
         <fj-page-preview :show="true" :route="config.preview_route" />
     </b-button>

--- a/resources/js/components/Fjord/BaseIndex/BaseIndexTableIndexIndicator.vue
+++ b/resources/js/components/Fjord/BaseIndex/BaseIndexTableIndexIndicator.vue
@@ -2,7 +2,7 @@
     <div>
         <small class="text-primary fj-crud-index-table__index-indicator">
             <template v-if="total">
-                {{ from }} - {{ to }} {{ $t('fj.of') }} {{ total }}
+                {{ from }} - {{ to }} {{ __('fj.of') }} {{ total }}
             </template>
         </small>
     </div>

--- a/resources/js/components/Fjord/BaseIndex/TableForm/BaseIndexTableFilter.vue
+++ b/resources/js/components/Fjord/BaseIndex/TableForm/BaseIndexTableFilter.vue
@@ -8,7 +8,7 @@
     >
         <template v-slot:button-content>
             <fa-icon icon="filter" />
-            <span class="d-none d-lg-inline-block">{{ $t('fj.filter') }}</span>
+            <span class="d-none d-lg-inline-block">{{ __('fj.filter') }}</span>
         </template>
 
         <b-dropdown-group

--- a/resources/js/components/Fjord/BaseIndex/TableForm/BaseIndexTableSearch.vue
+++ b/resources/js/components/Fjord/BaseIndex/TableForm/BaseIndexTableSearch.vue
@@ -1,7 +1,7 @@
 <template>
     <b-form-input
         :placeholder="
-            $t('fj.search_models', {
+            __('fj.search_models', {
                 models: namePlural
             })
         "
@@ -18,22 +18,22 @@ export default {
         },
         namePlural: {
             type: String
-        },
+        }
     },
     data() {
         return {
-            query: "",
-            typingDelay: 500,
-        }
+            query: '',
+            typingDelay: 500
+        };
     },
     watch: {
         query(val) {
             setTimeout(() => {
                 if (this.query == val) {
-                    this.$emit('search', val)
+                    this.$emit('search', val);
                 }
             }, this.typingDelay);
-        },
+        }
     }
 };
 </script>

--- a/resources/js/components/Fjord/BaseIndex/TableForm/BaseIndexTableSort.vue
+++ b/resources/js/components/Fjord/BaseIndex/TableForm/BaseIndexTableSort.vue
@@ -8,7 +8,7 @@
     >
         <template v-slot:button-content>
             <fa-icon icon="sort-amount-down" />
-            <span class="d-none d-lg-inline-block">{{ $t('fj.sort') }}</span>
+            <span class="d-none d-lg-inline-block">{{ __('fj.sort') }}</span>
         </template>
 
         <b-dropdown-item

--- a/resources/js/components/Fjord/Navigation.vue
+++ b/resources/js/components/Fjord/Navigation.vue
@@ -50,7 +50,7 @@
                         variant="outline-secondary"
                         class="btn-square mr-3"
                         v-b-tooltip
-                        :title="$t('fj.undo_changes')"
+                        :title="__('fj.undo_changes')"
                         @click="Fjord.bus.$emit('cancelSave')"
                     >
                         <fa-icon icon="undo" />
@@ -61,7 +61,7 @@
                         :disabled="!canSave"
                         @click="Fjord.bus.$emit('save')"
                     >
-                        {{ $t('fj.save') }}
+                        {{ __('fj.save') }}
                     </b-button>
                 </div>
             </div>

--- a/resources/js/components/Permissions/Extensions/PermissionsFjordUsersRoles.vue
+++ b/resources/js/components/Permissions/Extensions/PermissionsFjordUsersRoles.vue
@@ -43,7 +43,7 @@ export default {
             }
 
             this.$bvToast.toast(
-                this.$t('fjpermissions.role_removed', {
+                this.__('fjpermissions.role_removed', {
                     username: this.item.name,
                     role: this.translateRole(role)
                 }),

--- a/resources/js/components/Permissions/Permissions.vue
+++ b/resources/js/components/Permissions/Permissions.vue
@@ -136,7 +136,7 @@ export default {
                 this.roleNames.push({
                     id: role.id,
                     title: this.$te(tKey)
-                        ? this.$t(tKey).toString()
+                        ? this.__(tKey).toString()
                         : role.name.capitalize()
                 });
             }

--- a/resources/js/components/Permissions/PermissionsToggle.vue
+++ b/resources/js/components/Permissions/PermissionsToggle.vue
@@ -60,10 +60,10 @@ export default {
             }
 
             this.$bvToast.toast(
-                this.$t('fj.permission_updated', {
-                    operation: this.$t(`fj.${this.operation}`),
+                this.__('fj.permission_updated', {
+                    operation: this.__(`fj.${this.operation}`),
                     group: this.$te(`permissions.${this.group}`)
-                        ? this.$t(`permissions.${this.group}`).toString()
+                        ? this.__(`permissions.${this.group}`).toString()
                         : this.group.capitalize()
                 }),
                 {

--- a/resources/js/components/Permissions/RoleCreate.vue
+++ b/resources/js/components/Permissions/RoleCreate.vue
@@ -74,7 +74,7 @@ export default {
             this.visible = false;
 
             this.$bvToast.toast(
-                this.$t('fjpermissions.added_role', {
+                this.__('fjpermissions.added_role', {
                     role: role.name.capitalize()
                 }),
                 {

--- a/resources/js/components/Users/FjordUsers.vue
+++ b/resources/js/components/Users/FjordUsers.vue
@@ -3,7 +3,7 @@
         <fj-navigation>
             <fj-user-create @userCreated="userCreated" slot="right" />
         </fj-navigation>
-        <fj-header :title="'Fjord ' + $t('fj.users')" />
+        <fj-header :title="'Fjord ' + __('fj.users')" />
 
         <b-row>
             <b-col>
@@ -12,8 +12,8 @@
                     :cols="config.index"
                     :items="users"
                     :load-items="loadUsers"
-                    :name-singular="$t('fj.user')"
-                    :name-plural="$t('fj.users')"
+                    :name-singular="__('fj.user')"
+                    :name-plural="__('fj.users')"
                     :per-page="config.perPage"
                     :sort-by="config.sortBy"
                     :sort-by-default="config.sortByDefault"

--- a/resources/js/components/Users/UserCreate.vue
+++ b/resources/js/components/Users/UserCreate.vue
@@ -2,13 +2,13 @@
     <div class="d-inline-block">
         <b-button variant="primary" @click="visible = !visible">
             <fa-icon icon="plus" />
-            {{ $t('fj.add_model', { model: 'Fjord ' + $t('fj.user') }) }}
+            {{ __('fj.add_model', { model: 'Fjord ' + __('fj.user') }) }}
         </b-button>
         <b-modal
             v-model="visible"
-            :title="$t('fj.add_model', { model: 'Fjord ' + $t('fj.user') })"
+            :title="__('fj.add_model', { model: 'Fjord ' + __('fj.user') })"
         >
-            <b-form-group :label="$t('fj.enter_username')" label-for="username">
+            <b-form-group :label="__('fj.enter_username')" label-for="username">
                 <b-form-input
                     id="username"
                     v-model="user.username"
@@ -39,7 +39,7 @@
                 </b-form-invalid-feedback>
             </b-form-group>
             <b-form-group
-                :label="$t('fj.enter_email')"
+                :label="__('fj.enter_email')"
                 label-for="email"
                 :state="emailState"
             >
@@ -53,7 +53,7 @@
                 </b-form-invalid-feedback>
             </b-form-group>
             <b-form-group
-                :label="$t('fj.enter_password')"
+                :label="__('fj.enter_password')"
                 label-for="password"
                 :state="passwordState"
             >
@@ -89,7 +89,7 @@
                 name="check-button"
                 switch
             >
-                {{ $t('fj.user_reset_link') }}
+                {{ __('fj.user_reset_link') }}
             </b-form-checkbox>
             <template v-slot:modal-footer>
                 <div class="w-100">
@@ -108,8 +108,8 @@
                     >
                         <fa-icon icon="user" />
                         {{
-                            $t(`fj.create_model`, {
-                                model: 'Fjord ' + $t('fj.user')
+                            __(`fj.create_model`, {
+                                model: 'Fjord ' + __('fj.user')
                             })
                         }}
                         <b-spinner
@@ -160,7 +160,7 @@ export default {
             this.visible = false;
             this.init();
             this.$bvToast.toast(
-                this.$t('fj.model_saved', { model: 'Fjord User' }),
+                this.__('fj.model_saved', { model: 'Fjord User' }),
                 {
                     variant: 'success'
                 }


### PR DESCRIPTION
This pr replaces the i18n default `$t` method for Laravel like the `__` mixin.